### PR TITLE
Use different values for BT-164 and BT-65

### DIFF
--- a/src/test/technical-cases/01.01_comprehensive_test_ubl.xml
+++ b/src/test/technical-cases/01.01_comprehensive_test_ubl.xml
@@ -176,7 +176,7 @@
       <cbc:PostalZone>12345</cbc:PostalZone>
       <cbc:CountrySubentity>Bayern</cbc:CountrySubentity>
       <cac:AddressLine>
-        <cbc:Line>[Seller tax representative address line 2]</cbc:Line>
+        <cbc:Line>[Seller tax representative address line 3]</cbc:Line>
       </cac:AddressLine>
       <cac:Country>
         <cbc:IdentificationCode>DE</cbc:IdentificationCode>

--- a/src/test/technical-cases/01.01_comprehensive_test_uncefact.xml
+++ b/src/test/technical-cases/01.01_comprehensive_test_uncefact.xml
@@ -359,7 +359,7 @@
 					<!-- BT-65 -->
                     <ram:LineTwo>[Seller tax representative address line 2]</ram:LineTwo>
 					<!-- BT-164 -->
-                    <ram:LineThree>[Seller tax representative address line 2]</ram:LineThree>
+                    <ram:LineThree>[Seller tax representative address line 3]</ram:LineThree>
 					<!-- BT-66 -->
                     <ram:CityName>[Seller tax representative city]</ram:CityName>
 					<!-- BT-69 -->

--- a/src/test/technical-cases/01.02_comprehensive_test_ubl.xml
+++ b/src/test/technical-cases/01.02_comprehensive_test_ubl.xml
@@ -163,7 +163,7 @@
       <cbc:PostalZone>12345</cbc:PostalZone>
       <cbc:CountrySubentity>Bayern</cbc:CountrySubentity>
       <cac:AddressLine>
-        <cbc:Line>[Seller tax representative address line 2]</cbc:Line>
+        <cbc:Line>[Seller tax representative address line 3]</cbc:Line>
       </cac:AddressLine>
       <cac:Country>
         <cbc:IdentificationCode>DE</cbc:IdentificationCode>

--- a/src/test/technical-cases/01.02_comprehensive_test_uncefact.xml
+++ b/src/test/technical-cases/01.02_comprehensive_test_uncefact.xml
@@ -309,7 +309,7 @@
 					<!-- BT-65 -->
                     <ram:LineTwo>[Seller tax representative address line 2]</ram:LineTwo>
 					<!-- BT-164 -->
-                    <ram:LineThree>[Seller tax representative address line 2]</ram:LineThree>
+                    <ram:LineThree>[Seller tax representative address line 3]</ram:LineThree>
 					<!-- BT-66 -->
                     <ram:CityName>[Seller tax representative city]</ram:CityName>
 					<!-- BT-69 -->

--- a/src/test/technical-cases/01.03_comprehensive_test_ubl.xml
+++ b/src/test/technical-cases/01.03_comprehensive_test_ubl.xml
@@ -159,7 +159,7 @@
       <cbc:PostalZone>12345</cbc:PostalZone>
       <cbc:CountrySubentity>Bayern</cbc:CountrySubentity>
       <cac:AddressLine>
-        <cbc:Line>[Seller tax representative address line 2]</cbc:Line>
+        <cbc:Line>[Seller tax representative address line 3]</cbc:Line>
       </cac:AddressLine>
       <cac:Country>
         <cbc:IdentificationCode>DE</cbc:IdentificationCode>

--- a/src/test/technical-cases/01.03_comprehensive_test_uncefact.xml
+++ b/src/test/technical-cases/01.03_comprehensive_test_uncefact.xml
@@ -309,7 +309,7 @@
 					<!-- BT-65 -->
                     <ram:LineTwo>[Seller tax representative address line 2]</ram:LineTwo>
 					<!-- BT-164 -->
-                    <ram:LineThree>[Seller tax representative address line 2]</ram:LineThree>
+                    <ram:LineThree>[Seller tax representative address line 3]</ram:LineThree>
 					<!-- BT-66 -->
                     <ram:CityName>[Seller tax representative city]</ram:CityName>
 					<!-- BT-69 -->

--- a/src/test/technical-cases/01.04_comprehensive_test_ubl.xml
+++ b/src/test/technical-cases/01.04_comprehensive_test_ubl.xml
@@ -162,7 +162,7 @@
       <cbc:PostalZone>12345</cbc:PostalZone>
       <cbc:CountrySubentity>Bayern</cbc:CountrySubentity>
       <cac:AddressLine>
-        <cbc:Line>[Seller tax representative address line 2]</cbc:Line>
+        <cbc:Line>[Seller tax representative address line 3]</cbc:Line>
       </cac:AddressLine>
       <cac:Country>
         <cbc:IdentificationCode>DE</cbc:IdentificationCode>

--- a/src/test/technical-cases/01.04_comprehensive_test_uncefact.xml
+++ b/src/test/technical-cases/01.04_comprehensive_test_uncefact.xml
@@ -309,7 +309,7 @@
 					<!-- BT-65 -->
                     <ram:LineTwo>[Seller tax representative address line 2]</ram:LineTwo>
 					<!-- BT-164 -->
-                    <ram:LineThree>[Seller tax representative address line 2]</ram:LineThree>
+                    <ram:LineThree>[Seller tax representative address line 3]</ram:LineThree>
 					<!-- BT-66 -->
                     <ram:CityName>[Seller tax representative city]</ram:CityName>
 					<!-- BT-69 -->


### PR DESCRIPTION
In all `comprehensive` files, the value `[Seller tax representative address line 2]` of field `BT-65` (`Tax representative address line 2`) is also used for field `BT-164` (`Tax representative address line 3`). This change sets the unique value `[Seller tax representative address line 3]` for the field `BT-164`.